### PR TITLE
fix: specify build output directory for Vercel static deployment in v…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "builds": [
+    {
+      "src": "dist/spa/**",
+      "use": "@vercel/static"
+    }
+  ],
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
This PR migrates the project for proper Vercel deployment:

- Moves API endpoints to `/api` as Vercel serverless functions
- Updates `vite.config.ts` to use the correct static output directory
- Adds `vercel.json` for SPA rewrites and output directory
- Removes server-side Express logic from production build

Closes #1